### PR TITLE
Change font library

### DIFF
--- a/lyricsheets/ass/consts.py
+++ b/lyricsheets/ass/consts.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 import pyass
 
 # Styles
@@ -77,4 +75,3 @@ LYRICS_TAGS = pyass.Tags(
         pyass.AlignmentTag(pyass.Alignment.CENTER),
     ]
 )
-

--- a/lyricsheets/ass/to_ass.py
+++ b/lyricsheets/ass/to_ass.py
@@ -154,4 +154,4 @@ def register_effect(name: str, effect: Effect):
 
 
 def retrieve_effect(name: str):
-    return _effects.get(name)
+    return _effects[name]

--- a/lyricsheets/cache/models.py
+++ b/lyricsheets/cache/models.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from datetime import timedelta
 from typing import Optional, Protocol
 
 

--- a/lyricsheets/effect/default_effect.py
+++ b/lyricsheets/effect/default_effect.py
@@ -51,7 +51,7 @@ def get_enter_transition_tag(
     resultTag: Sequence[pyass.Tag] = [pyass.AlphaTag(0x00)],
 ) -> pyass.Tag:
     return pyass.TransformTag(
-        start=kChar.fadeOffset, end=switchDuration + kChar.fadeOffset, to=resultTag
+        start=kChar.fadeOffset, end=switchDuration + kChar.fadeOffset, to=list(resultTag)
     )
 
 
@@ -70,7 +70,7 @@ def get_exit_transition_tag(
         - transitionDuration
         + 2 * switchDuration
         + kChar.fadeOffset,
-        to=resultTag,
+        to=list(resultTag),
     )
 
 
@@ -85,7 +85,7 @@ def get_char_actor_tag(
         pyass.TransformTag(
             start=time + kChar.fadeOffset,
             end=time + kChar.fadeOffset,
-            to=actorToStyle[actor],
+            to=list(actorToStyle[actor]),
         )
         for time, actor in kChar.line.actorSwitches
     ]
@@ -101,7 +101,7 @@ def get_char_karaoke_tag(
         return [pyass.KaraokeTag(kChar.karaDuration)]
     else:
         return [
-            pyass.TransformTag(start=kChar.karaStart, end=kChar.karaEnd, to=resultTag)
+            pyass.TransformTag(start=kChar.karaStart, end=kChar.karaEnd, to=list(resultTag))
         ]
 
 

--- a/lyricsheets/effect/plain_effect.py
+++ b/lyricsheets/effect/plain_effect.py
@@ -19,7 +19,7 @@ def to_plain_event(line: KLine) -> pyass.Event:
                 ],
                 text=syl.text,
             )
-            for syl, syl2 in zip(line.kara, [None] + line.kara[:-1])
+            for syl, syl2 in zip(line.kara, [None] + list(line.kara[:-1]))
         ],
     )
 

--- a/lyricsheets/models/karaoke.py
+++ b/lyricsheets/models/karaoke.py
@@ -1,23 +1,17 @@
 from dataclasses import dataclass
 from datetime import timedelta
 from functools import reduce
-from itertools import accumulate
-from typing import Sequence
+from typing import Sequence, TypeVar
 
 from lyricsheets.models import SongLine
-
 from lyricsheets.fonts import FontScaler
 
 import pyass
 from pyass import Style
 
-
-class KLine:
-    pass
-
-
-class KSyl:
-    pass
+KChar = TypeVar("KChar", bound="KChar")
+KSyl = TypeVar("KSyl", bound="KSyl")
+KLine = TypeVar("KLine", bound="KLine")
 
 
 @dataclass
@@ -25,12 +19,13 @@ class KChar:
     char: str
     i: int
     sylI: int
-    fadeOffset: timedelta() = timedelta()
-    karaStart: timedelta() = timedelta()
-    karaEnd: timedelta() = timedelta()
+    line: KLine
+    syl: KSyl
 
-    line: KLine = None
-    syl: KSyl = None
+    fadeOffset: timedelta = timedelta()
+    karaStart: timedelta = timedelta()
+    karaEnd: timedelta = timedelta()
+
 
     @property
     def karaDuration(self) -> timedelta:
@@ -39,13 +34,13 @@ class KChar:
 
 @dataclass
 class KSyl:
-    start: timedelta()
-    end: timedelta()
-    chars: Sequence[KChar]
+    start: timedelta
+    end: timedelta
+    chars: list[KChar]
     inlineFx: str
     i: int
 
-    line: KLine = None
+    line: KLine
 
     @property
     def text(self) -> str:
@@ -76,11 +71,11 @@ class KSyl:
 
 @dataclass
 class KLine:
-    start: timedelta()
-    end: timedelta()
-    kara: Sequence[KSyl]
+    start: timedelta
+    end: timedelta
+    kara: list[KSyl]
     startActor: str
-    actorSwitches: Sequence[tuple[int, str]]
+    actorSwitches: list[tuple[timedelta, str]]
     isSecondary: bool
     isAlone: bool
     isEN: bool
@@ -202,7 +197,7 @@ def to_en_k_line(line: SongLine, lineNum: int = 0) -> KLine:
         start=line.start,
         end=line.start,
         chars=[],
-        inlineFx=None,
+        inlineFx='',
         i=0,
         line=kLineEN,
     )

--- a/lyricsheets/models/karaoke.py
+++ b/lyricsheets/models/karaoke.py
@@ -56,7 +56,7 @@ class KSyl:
         return self.end - self.start
 
     def calculate_char_kara_times(self, style: Style):
-        fontScaler = FontScaler(style.fontName, style.fontSize)
+        fontScaler = FontScaler(style)
 
         syllableCharLengths = [
             timedelta(milliseconds=c * 10)
@@ -104,7 +104,7 @@ class KLine:
             k.calculate_char_kara_times(style)
 
     def calculate_char_fade_offsets(self, style: Style, transitionDuration: timedelta):
-        fontScaler = FontScaler(style.fontName, style.fontSize)
+        fontScaler = FontScaler(style)
 
         lineCharTimes = [
             timedelta(milliseconds=m)

--- a/lyricsheets/models/song.py
+++ b/lyricsheets/models/song.py
@@ -1,11 +1,10 @@
-from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Optional
 
 from dataclass_wizard import JSONWizard
 
-from .modifier import Modifier, Modifiers
+from .modifier import Modifiers
 
 
 @dataclass

--- a/lyricsheets/sheets/client.py
+++ b/lyricsheets/sheets/client.py
@@ -31,7 +31,7 @@ class GoogleSheetsClient:
 
     @on_exception(
         expo,
-        HttpError,
+        exception=HttpError,
         giveup=lambda e: not isinstance(e, HttpError)
         or e.status_code != HTTPStatus.TOO_MANY_REQUESTS,
         max_tries=10,
@@ -45,7 +45,7 @@ class GoogleSheetsClient:
 
     @on_exception(
         expo,
-        HttpError,
+        exception=HttpError,
         giveup=lambda e: not isinstance(e, HttpError)
         or e.status_code != HTTPStatus.TOO_MANY_REQUESTS,
         max_tries=10,
@@ -57,7 +57,7 @@ class GoogleSheetsClient:
 
     @on_exception(
         expo,
-        HttpError,
+        exception=HttpError,
         giveup=lambda e: not isinstance(e, HttpError)
         or e.status_code != HTTPStatus.TOO_MANY_REQUESTS,
         max_tries=10,
@@ -80,7 +80,7 @@ class GoogleSheetsClient:
 
     @on_exception(
         expo,
-        HttpError,
+        exception=HttpError,
         giveup=lambda e: not isinstance(e, HttpError)
         or e.status_code != HTTPStatus.TOO_MANY_REQUESTS,
         max_tries=10,

--- a/lyricsheets/sheets/decorator.py
+++ b/lyricsheets/sheets/decorator.py
@@ -20,7 +20,7 @@ def token_bucket(key: str, num_tokens: int):
         class RateLimitException(Exception):
             pass
 
-        @on_exception(expo, RateLimitException)
+        @on_exception(expo, exception=RateLimitException)
         def wrapper(self: WithTokenBucket, *args, **kwargs):
             if not self.bucket.consume(key=key, num_tokens=num_tokens):
                 raise RateLimitException()

--- a/lyricsheets/web/app.py
+++ b/lyricsheets/web/app.py
@@ -14,7 +14,7 @@ with open(config_file_path) as f:
     redis_cfg = cfg['redis']
 
 songServer = SongServiceByDB(
-    cfg['google_credentials'], cfg['spreadsheet_id'],
+    cfg['google_credentials'], cfg['spreadsheet_id'], cfg['default'],
     RedisCache(redis_cfg['host'], redis_cfg['port'], redis_cfg['db'])
 )
 app = Flask(__name__)

--- a/populate_songs.py
+++ b/populate_songs.py
@@ -2,7 +2,7 @@ import argparse
 from collections.abc import Mapping, Sequence
 from datetime import timedelta
 import functools
-import importlib
+import importlib.util
 import json
 import os
 import pyass
@@ -74,6 +74,9 @@ def populate_song(
     for modifier in allModifiers:
         if modifier.operation == "import":
             spec = importlib.util.find_spec(modifier.rest[0])
+            if not spec or not spec.loader:
+                raise ModuleNotFoundError
+
             lib = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(lib)
         elif modifier.operation == "kfx":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 backoff==2.2.1
-dataclass_wizard==0.22.2
+dataclass-wizard==0.22.2
 Flask==2.2.2
-google_api_python_client==2.65.0
-matplotlib==3.7.1
-Pillow==9.5.0
-protobuf==4.22.3
-pyass==0.1.1
-token_bucket==0.3.0
+google-api-python-client==2.65.0
+pyass==0.1.2
+redis==4.4.0
+token-bucket==0.3.0
+wxPython==4.2.1


### PR DESCRIPTION
Changed font library from PIL to wxPython given that the former is inaccurate and does not match up with Aegisub.

Given that wxPython just uses the win32 API in the backend if it is running on a Windows system, we can just use wxPython on all platforms to avoid an additional explicit dependency on pywin32 and have two platform-dependent versions of the class.