### PR TITLE
Add script to edit song karaoke

### DIFF
--- a/create_song.py
+++ b/create_song.py
@@ -39,7 +39,7 @@ def main():
         config["default"],
     )
 
-    songService.save_song(song, args.group)
+    songService.create_song(song, args.group)
 
 
 if __name__ == "__main__":

--- a/edit_song_karaoke.py
+++ b/edit_song_karaoke.py
@@ -1,0 +1,70 @@
+import argparse
+import json
+import os
+import platform
+import subprocess
+import tempfile
+import pyass
+
+from lyricsheets.ass import read_karaoke
+from lyricsheets.cache import MemoryCache
+from lyricsheets.effect import KaraokeOnlyEffect
+from lyricsheets.service import SongServiceByDB
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Edits karaoke timing and updates it Google Sheets"
+    )
+
+    parser.add_argument("title", help="Title of the song")
+    parser.add_argument("--group", help="Group that sang the song")
+    parser.add_argument("--config", help="Path to config file", default="./config.json")
+
+    args = parser.parse_args()
+
+    with open(args.config) as f:
+        config = json.load(f)
+
+    songService = SongServiceByDB(
+        config["google_credentials"],
+        config["spreadsheets"],
+        config["default"],
+        MemoryCache(),
+    )
+
+    print("Fetching song...")
+    song = songService.get_song(args.title)
+    script = pyass.Script(
+        styles=[pyass.Style()], events=KaraokeOnlyEffect().to_events(song, {}, False)
+    )
+
+    print("Creating temporary file...")
+    f = tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf_8_sig", suffix=".ass", delete=False
+    )
+    pyass.dump(script, f)
+    f.close()
+
+    fileNameForAegisub = f.name
+    if "microsoft-standard-WSL" in platform.uname().release:
+        out = subprocess.run(
+            ["wslpath", "-w", f.name], capture_output=True, check=True, text=True
+        )
+        fileNameForAegisub = out.stdout
+
+    print("Waiting for file to be closed...")
+    subprocess.run(
+        ["powershell.exe", "-command", "start", "-Wait", fileNameForAegisub], check=True
+    )
+    print("File closed")
+
+    with open(f.name, encoding="utf_8_sig") as f:
+        song.lyrics = read_karaoke(pyass.load(f).events)
+        songService.update_song_karaoke(song)
+
+    os.remove(f.name)
+
+
+if __name__ == "__main__":
+    main()

--- a/lyricsheets/cache/memory.py
+++ b/lyricsheets/cache/memory.py
@@ -15,3 +15,6 @@ class MemoryCache(Cache):
 
     def set(self, key: str, val: bytes):
         self.cache[key] = val
+
+    def delete(self, key: str):
+        del self.cache[key]

--- a/lyricsheets/cache/models.py
+++ b/lyricsheets/cache/models.py
@@ -11,6 +11,9 @@ class Cache(ABC):
     def set(self, key: str, val: bytes):
         ...
 
+    @abstractmethod
+    def delete(self, key: str):
+        ...
 
 class Cacheable(Protocol):
     cache: Cache

--- a/lyricsheets/cache/redis.py
+++ b/lyricsheets/cache/redis.py
@@ -14,3 +14,6 @@ class RedisCache(Cache):
 
     def set(self, key: str, val: bytes):
         self.cache.set(key, val)
+
+    def delete(self, key: str):
+        self.cache.delete(key)

--- a/lyricsheets/effect/__init__.py
+++ b/lyricsheets/effect/__init__.py
@@ -2,3 +2,4 @@ from .default_effect import *
 from .no_karaoke_effect import *
 from .no_lyrics_effect import *
 from .plain_effect import *
+from .karaoke_only_effect import *

--- a/lyricsheets/effect/karaoke_only_effect.py
+++ b/lyricsheets/effect/karaoke_only_effect.py
@@ -1,0 +1,29 @@
+from collections.abc import Mapping, Sequence
+
+from lyricsheets.models import Song, SongLine, SongLineSyllable
+
+import pyass
+
+from ..ass.to_ass import Effect
+
+
+class KaraokeOnlyEffect(Effect):
+    def to_events(
+        self,
+        song: Song,
+        actorToStyle: Mapping[str, Sequence[pyass.Tag]],
+        shouldPrintTitle: bool = True,
+    ) -> Sequence[pyass.Event]:
+        return [self.to_event(line) for line in song.lyrics]
+
+    def to_event(self, line: SongLine) -> pyass.Event:
+        return pyass.Event(
+            start=line.start,
+            end=line.end,
+            parts=[self.to_event_part(syl) for syl in line.syllables],
+        )
+
+    def to_event_part(self, syl: SongLineSyllable) -> pyass.EventPart:
+        return pyass.EventPart(
+            tags=[pyass.KaraokeTag(syl.length, False)], text=syl.text
+        )

--- a/lyricsheets/models/song.py
+++ b/lyricsheets/models/song.py
@@ -69,8 +69,8 @@ class Song(JSONWizard):
     class _(JSONWizard.Meta):
         skip_defaults = True
 
-    title: SongTitle = SongTitle()
-    creators: SongCreators = SongCreators()
+    title: SongTitle = field(default_factory=SongTitle)
+    creators: SongCreators = field(default_factory=SongCreators)
     lyrics: list[SongLine] = field(default_factory=list)
 
     @property

--- a/lyricsheets/service/service.py
+++ b/lyricsheets/service/service.py
@@ -22,5 +22,9 @@ class SongService:
         ...
 
     @abstractmethod
-    def save_song(self, song: Song, group: str = ""):
+    def create_song(self, song: Song, group: str = ""):
+        ...
+
+    @abstractmethod
+    def update_song_karaoke(self, song: Song):
         ...


### PR DESCRIPTION
Resolve the pain point where everything but the timings/karaoke can be edited easily through the Google Sheets.

The `edit_song_karaoke.py` script:

1. Gets the song
2. Creates a temporary .ass file containing the song timings to be edited
3. Opens the file in Aegisub and blocks until the file is closed

The user can then edit the song timings using Aegisub.

After the temporary .ass file is closed, the script resumes and:

1. Compares the original song and the update song to find the differences in line/syllable timings
2. Updates the changed lines/syllables in Google Sheets