### PR TITLE
Added dupe modifier

### DIFF
--- a/lyricsheets/models/song.py
+++ b/lyricsheets/models/song.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any
+from copy import deepcopy
 
 from dataclass_wizard import JSONWizard
 
@@ -90,6 +91,8 @@ class Song(JSONWizard):
     def modify(self, modifiers: Modifiers):
         lineModifiers = modifiers.toLineModifiers(maxLines=len(self.lyrics))
         outLyrics = []
+        additionalLineNumber = len(self.lyrics)
+        extraLyrics = []
         for line, modifier in zip(self.lyrics, lineModifiers):
             # Song-related modifiers
             if modifier.shouldOverwriteTitle:
@@ -131,7 +134,21 @@ class Song(JSONWizard):
                 line.end += modifier.offset - modifier.trim
                 line.syllables[-1].length -= modifier.trim
 
+            # Duplicate modifiers
+            if modifier.dupes:
+                for offset in modifier.dupes:
+                    dupeLine = deepcopy(line)
+                    dupeLine.idxInSong = additionalLineNumber
+                    dupeLine.start += offset
+                    dupeLine.end += offset
+
+                    additionalLineNumber += 1
+
+                    extraLyrics.append(dupeLine)
+
             outLyrics.append(line)
+        
+        outLyrics.extend(extraLyrics)
 
         if lineModifiers[0].newOrder is None:
             self.lyrics = outLyrics

--- a/lyricsheets/models/song.py
+++ b/lyricsheets/models/song.py
@@ -91,7 +91,6 @@ class Song(JSONWizard):
     def modify(self, modifiers: Modifiers):
         lineModifiers = modifiers.toLineModifiers(maxLines=len(self.lyrics))
         outLyrics = []
-        additionalLineNumber = len(self.lyrics)
         extraLyrics = []
         for line, modifier in zip(self.lyrics, lineModifiers):
             # Song-related modifiers
@@ -138,11 +137,9 @@ class Song(JSONWizard):
             if modifier.dupes:
                 for offset in modifier.dupes:
                     dupeLine = deepcopy(line)
-                    dupeLine.idxInSong = additionalLineNumber
+                    dupeLine.idxInSong = len(self.lyrics) + len(extraLyrics)
                     dupeLine.start += offset
                     dupeLine.end += offset
-
-                    additionalLineNumber += 1
 
                     extraLyrics.append(dupeLine)
 


### PR DESCRIPTION
Adds a modifier to duplicate lyric lines in a song.

The selected lines are duplicated and then offset by a specified timedelta. A duplicated line is processed after all other modifiers are applied to it, and is given a new value for `idxInLine` that starts after the last line in the song, regardless of its timing. It is executed as a deep copy, so any further modifications after will need to be conducted on both the original and the duplicated line, or one or the other if the user so chooses..