### PR TITLE
Update KSyl and KChar to 1-based indexing

### DIFF
--- a/lyricsheets/models/karaoke.py
+++ b/lyricsheets/models/karaoke.py
@@ -489,7 +489,7 @@ def to_romaji_k_line(line: SongLine) -> KLine:
         for c in syl.text:
             kChar = KChar(
                 text=c,
-                idxInLine=totalChars,
+                idxInLine=totalChars+1,
                 idxInSyl=len(kSyl.chars)+1,
                 syl=kSyl,
                 line=kLine,

--- a/lyricsheets/models/karaoke.py
+++ b/lyricsheets/models/karaoke.py
@@ -482,7 +482,7 @@ def to_romaji_k_line(line: SongLine) -> KLine:
             end=accLength + syl.length,
             inlineFx=actor,
             chars=[],
-            idxInLine=len(kLine.syls),
+            idxInLine=len(kLine.syls)+1,
             line=kLine,
         )
 
@@ -490,7 +490,7 @@ def to_romaji_k_line(line: SongLine) -> KLine:
             kChar = KChar(
                 text=c,
                 idxInLine=totalChars,
-                idxInSyl=len(kSyl.chars),
+                idxInSyl=len(kSyl.chars)+1,
                 syl=kSyl,
                 line=kLine,
             )
@@ -529,15 +529,15 @@ def to_en_k_line(line: SongLine) -> KLine:
         end=line.start,
         chars=[],
         inlineFx="",
-        idxInLine=0,
+        idxInLine=1,
         line=kLineEN,
     )
 
     kSylEN.chars = [
         KChar(
             text=char,
-            idxInLine=i,
-            idxInSyl=i,
+            idxInLine=i+1,
+            idxInSyl=i+1,
             syl=kSylEN,
             line=kLineEN,
         )

--- a/lyricsheets/models/karaoke.py
+++ b/lyricsheets/models/karaoke.py
@@ -61,11 +61,11 @@ class KChar:
 
     @property
     def start(self) -> timedelta:
-        return self.syl._charKaraTimes[self.idxInSyl]
+        return self.syl._charKaraTimes[self.idxInSyl - 1]
 
     @property
     def end(self) -> timedelta:
-        return self.syl._charKaraTimes[self.idxInSyl + 1]
+        return self.syl._charKaraTimes[self.idxInSyl]
 
     @property
     def duration(self) -> timedelta:
@@ -117,7 +117,7 @@ class KChar:
 
     @property
     def fadeOffset(self) -> timedelta:
-        return self.line._charFadeOffsets[self.idxInLine]
+        return self.line._charFadeOffsets[self.idxInLine - 1]
 
 
 @dataclass

--- a/lyricsheets/models/karaoke.py
+++ b/lyricsheets/models/karaoke.py
@@ -81,10 +81,10 @@ class KChar:
 
     @cached_property
     def left(self) -> float:
-        if self.idxInLine == 0:
+        if self.idxInLine == 1:
             return self.line.left
 
-        prevChar = self.line.chars[self.idxInLine - 1]
+        prevChar = self.line.chars[self.idxInLine - 2]
         return prevChar.left + prevChar.width
 
     @property
@@ -176,10 +176,10 @@ class KSyl:
 
     @cached_property
     def left(self) -> float:
-        if self.idxInLine == 0:
+        if self.idxInLine == 1:
             return self.line.left + self.preSpaceWidth
 
-        prevSyl = self.line.syls[self.idxInLine - 1]
+        prevSyl = self.line.syls[self.idxInLine - 2]
         return (
             prevSyl.left + prevSyl.width + prevSyl.postSpaceWidth + self.preSpaceWidth
         )


### PR DESCRIPTION
I have unfortunately discovered that Aegisub's Karaoke Templater also uses 1-based indexing for syllables (probably a feature of Lua). The data structures of `KSyl` and `KChar` have been updated to follow that.