### PR TITLE
Fix text-extents bugs

### DIFF
--- a/lyricsheets/fonts/fonts.py
+++ b/lyricsheets/fonts/fonts.py
@@ -38,7 +38,7 @@ class FontScaler:
 
         return ans
 
-    def get_length(self, text: str) -> int:
+    def get_length(self, text: str) -> float:
         width = 0
         if self.style.spacing:
             for c in text:
@@ -58,7 +58,7 @@ class FontScaler:
             )
             width = extent.width * scaling
 
-        return int(round(self.style.scaleX / 100 * width / PRECISION_SCALE, 0))
+        return self.style.scaleX / 100 * width / PRECISION_SCALE
 
 
 def _find_font(style: Style) -> wx.Font:

--- a/lyricsheets/models/karaoke.py
+++ b/lyricsheets/models/karaoke.py
@@ -170,7 +170,7 @@ class KSyl:
         numPostSpaces = len(self.text) - len(self.text.rstrip())
         return (
             FontScaler(self.style).get_length(self.text[-(numPostSpaces):])
-            if numPostSpaces
+            if numPostSpaces and numPostSpaces != len(self.text)
             else 0
         )
 

--- a/lyricsheets/models/song.py
+++ b/lyricsheets/models/song.py
@@ -147,7 +147,7 @@ class Song(JSONWizard):
         
         outLyrics.extend(extraLyrics)
 
-        if len(lineModifiers) == 0 or lineModifiers[0].newOrder is None:
+        if lineModifiers[0].newOrder is None:
             self.lyrics = outLyrics
             return self
 

--- a/lyricsheets/models/song.py
+++ b/lyricsheets/models/song.py
@@ -147,7 +147,7 @@ class Song(JSONWizard):
         
         outLyrics.extend(extraLyrics)
 
-        if lineModifiers[0].newOrder is None:
+        if len(lineModifiers) == 0 or lineModifiers[0].newOrder is None:
             self.lyrics = outLyrics
             return self
 


### PR DESCRIPTION
Fixes two bugs.

1. Inconsistent values for `KChar` and `KSyl` widths. This was caused by rounding in `get_lengths()` in fonts.py. The rounding has been removed.
2. A `KSyl` with only whitespace has its width double counted by the next `KSyl` in the line, thus moving it more right than it's supposed to. This is fixed by setting `postSpaceWidth` to `0` if a `KSyl` consists of only spaces, which is consistent with the behavior is `karaskel.lua`.